### PR TITLE
"TLS error from peer" patch 

### DIFF
--- a/Scripts/installer.sh
+++ b/Scripts/installer.sh
@@ -167,7 +167,7 @@ do
                         DIR1=/usr/data/moonraker/
             			DIR2=/usr/data/fluidd/
             			DIR3=/usr/data/mainsail/
-            			URL="https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker.tar"
+            			URL="https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker.tar"
             			if [ -d "$DIR1" ];
             			then
             				printf "${darkred} Moonraker and Nginx are already installed!${white}\n\n"
@@ -185,19 +185,19 @@ do
                 			        [ ! -e /etc/init.d/S56moonraker_service ] && cp moonraker/S56moonraker_service /etc/init.d/
                 			        rm -f moonraker.tar
                 			        if [ ! -d "$DIR2" -a -d "$DIR3" ]; then
-                    			        wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_mainsail.conf
+                    			        wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_mainsail.conf
                     			        cp moonraker_mainsail.conf /usr/data/printer_data/config/moonraker.conf
                     			        rm -f moonraker_mainsail.conf
                 			        elif [ -d "$DIR2" -a ! -d "$DIR3" ]; then
-                    			        wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_fluidd.conf
+                    			        wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_fluidd.conf
                     			        cp moonraker_fluidd.conf /usr/data/printer_data/config/moonraker.conf
                     			        rm -f moonraker_fluidd.conf
                 			        elif [ -d "$DIR2" -a -d "$DIR3" ]; then
-                    			        wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_both.conf
+                    			        wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_both.conf
                     			        cp moonraker_both.conf /usr/data/printer_data/config/moonraker.conf
                     			        rm -f moonraker_both.conf
                 			        else
-                    			        wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker.conf
+                    			        wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker.conf
                     			        cp moonraker.conf /usr/data/printer_data/config/moonraker.conf
                     			        rm -f moonraker.conf
                 			        fi
@@ -241,11 +241,11 @@ do
                 			        cd /usr/data/fluidd
                 			        unzip fluidd.zip && rm fluidd.zip
                 			        if [ -d "$DIR2" ]; then
-                    			        wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_both.conf
+                    			        wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_both.conf
                     			        cp moonraker_both.conf /usr/data/printer_data/config/moonraker.conf
                     			        rm -f moonraker_both.conf
                 			        else
-                    			        wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_fluidd.conf
+                    			        wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_fluidd.conf
                     			        cp moonraker_fluidd.conf /usr/data/printer_data/config/moonraker.conf
                     			        rm -f moonraker_fluidd.conf
                 			        fi
@@ -288,11 +288,11 @@ do
                 			        cd /usr/data/mainsail
                 			        unzip mainsail.zip && rm mainsail.zip
                 			        if [ -d "$DIR2" ]; then
-                    			        wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_both.conf
+                    			        wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_both.conf
                     			        cp moonraker_both.conf /usr/data/printer_data/config/moonraker.conf
                     			        rm -f moonraker_both.conf
                 			        else
-                    			        wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_mainsail.conf
+                    			        wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_mainsail.conf
                     			        cp moonraker_mainsail.conf /usr/data/printer_data/config/moonraker.conf
                     			        rm -f moonraker_mainsail.conf
                 			        fi
@@ -324,24 +324,24 @@ do
             			    printf "${white}\n"
             			    if [ "$confirm" = "y" -o "$confirm" = "Y" ]; then
                 			    cd /usr/data
-                			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/timelapse/timelapse.py
-                			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/timelapse/timelapse.cfg
+                			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/timelapse/timelapse.py
+                			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/timelapse/timelapse.cfg
                 			    mv timelapse.py moonraker/moonraker/moonraker/components/
                 			    mv timelapse.cfg printer_data/config/
                 			    if [ ! -d "$DIR1" -a -d "$DIR2" ]; then
-                    			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_mainsail.conf
+                    			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_mainsail.conf
                     			    cp moonraker_mainsail.conf /usr/data/printer_data/config/moonraker.conf
                     			    rm -f moonraker_mainsail.conf
                 			    elif [ -d "$DIR1" -a ! -d "$DIR2" ]; then
-                    			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_fluidd.conf
+                    			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_fluidd.conf
                     			    cp moonraker_fluidd.conf /usr/data/printer_data/config/moonraker.conf
                     			    rm -f moonraker_fluidd.conf
                 			    elif [ -d "$DIR1" -a -d "$DIR2" ]; then
-                    			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_both.conf
+                    			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_both.conf
                     			    cp moonraker_both.conf /usr/data/printer_data/config/moonraker.conf
                     			    rm -f moonraker_both.conf
                 			    else
-                    			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker.conf
+                    			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker.conf
                     			    cp moonraker.conf /usr/data/printer_data/config/moonraker.conf
                     			    rm -f moonraker.conf
                 			    fi
@@ -397,7 +397,7 @@ do
                 			    git clone --depth 1 https://github.com/Clon1998/mobileraker_companion
                 			    cd mobileraker_companion
                 			    echo 'Getting K1 compatibility patches...'
-                			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/mobileraker/mobileraker-companion-k1-no-tzlocal.patch
+                			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/mobileraker/mobileraker-companion-k1-no-tzlocal.patch
                 			    echo 'Applying K1 compatibility patches...'
                 			    patch -p1 < mobileraker-companion-k1-no-tzlocal.patch
                 			    echo "Adding startup script..."
@@ -455,7 +455,7 @@ do
             			    if [ "$confirm" = "y" -o "$confirm" = "Y" ]; then
                 			    printf "${green}Installing Hotsname Service file...${white}\n"
                 			    cd /etc/init.d/
-                			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/services/S00hostname
+                			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/services/S00hostname
                 			    chmod 755 S00hostname
                 			    printf "\n${green} Hotsname Service ${white}file has been installed ${green}successfully${white}!\n\n"
                 			elif [ "$confirm" = "n" -o "$confirm" = "N" ]; then
@@ -467,8 +467,8 @@ do
                         ;;
                     9)
                         DIR=/etc/boot-display
-                        URL1="https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/boot-display/k1_boot_display.tar"
-                        URL2="https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/boot-display/k1max_boot_display.tar"
+                        URL1="hhttps://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/boot-display/k1_boot_display.tar"
+                        URL2="https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/boot-display/k1max_boot_display.tar"
             			if [ ! -d "$DIR" ]; then
             				printf "${darkred} Please use latest firmware to install Custom Boot Display!${white}\n\n"
             			else
@@ -525,10 +525,10 @@ do
             			    if [ "$confirm" = "y" -o "$confirm" = "Y" ]; then
                 			    printf "${green}Installing Buzzer Support files...${white}\n"
                 			    if [ ! -f "$FILE1" ]; then
-                			        wget --no-check-certificate -P /usr/share/klipper/klippy/extras/ https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/buzzer/gcode_shell_command.py
+                			        wget --no-check-certificate -P /usr/share/klipper/klippy/extras/ https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/buzzer/gcode_shell_command.py
                 			    fi
                 			    if [ ! -f "$FILE2" ]; then
-                			        wget --no-check-certificate -P /usr/data/ https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/buzzer/beep.mp3
+                			        wget --no-check-certificate -P /usr/data/ https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/buzzer/beep.mp3
                 			    fi
                 			    /etc/init.d/S55klipper_service restart
                 			    printf "\n${green} Buzzer Support ${white}files have been installed ${green}successfully${white}!\n\n"
@@ -582,11 +582,11 @@ do
                             if [ "$confirm" = "y" -o "$confirm" = "Y" ]; then
                 			    rm -rf /usr/data/fluidd
                 			    if [ -d "$DIR2" -a -d "$DIR3" ]; then
-                    			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_mainsail.conf
+                    			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_mainsail.conf
                     			    cp moonraker_mainsail.conf /usr/data/printer_data/config/moonraker.conf
                     			    rm -f moonraker_mainsail.conf
                 			    elif [ -d "$DIR3" ]; then
-                    			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker.conf
+                    			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker.conf
                     			    cp moonraker.conf /usr/data/printer_data/config/moonraker.conf
                     			    rm -f moonraker.conf
                 			    fi
@@ -611,11 +611,11 @@ do
                             if [ "$confirm" = "y" -o "$confirm" = "Y" ]; then
                 			    rm -rf /usr/data/mainsail
                 			    if [ -d "$DIR1" -a -d "$DIR3" ]; then
-                    			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker_fluidd.conf
+                    			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/moonraker/moonraker_fluidd.conf
                     			    cp moonraker_fluidd.conf /usr/data/printer_data/config/moonraker.conf
                     			    rm -f moonraker_fluidd.conf
                 			    elif [ -d "$DIR3" ]; then
-                    			    wget --no-check-certificate https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/moonraker/moonraker.conf
+                    			    wget --no-check-certificate https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/main/Scripts/files/moonraker/moonraker.conf
                     			    cp moonraker.conf /usr/data/printer_data/config/moonraker.conf
                     			    rm -f moonraker.conf
                 			    fi

--- a/Scripts/installer.sh
+++ b/Scripts/installer.sh
@@ -269,7 +269,7 @@ do
                         DIR1=/usr/data/mainsail/
             			DIR2=/usr/data/fluidd/
             			DIR3=/usr/data/moonraker/
-            			URL="https://github.com/mainsail-crew/mainsail/releases/download/v2.7.1/mainsail.zip"
+            			URL="https://github.com/mainsail-crew/mainsail/releases/latest/download/mainsail.zip"
             			if [ -d "$DIR1" ]; then
             				printf "${darkred} Mainsail is already installed!${white}\n\n"
             			elif [ ! -d "$DIR3" ]; then
@@ -467,7 +467,7 @@ do
                         ;;
                     9)
                         DIR=/etc/boot-display
-                        URL1="hhttps://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/boot-display/k1_boot_display.tar"
+                        URL1="https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/boot-display/k1_boot_display.tar"
                         URL2="https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/boot-display/k1max_boot_display.tar"
             			if [ ! -d "$DIR" ]; then
             				printf "${darkred} Please use latest firmware to install Custom Boot Display!${white}\n\n"

--- a/Scripts/installer.sh
+++ b/Scripts/installer.sh
@@ -269,7 +269,7 @@ do
                         DIR1=/usr/data/mainsail/
             			DIR2=/usr/data/fluidd/
             			DIR3=/usr/data/moonraker/
-            			URL="https://github.com/mainsail-crew/mainsail/releases/latest/download/mainsail.zip"
+            			URL="https://github.com/mainsail-crew/mainsail/releases/download/v2.7.1/mainsail.zip"
             			if [ -d "$DIR1" ]; then
             				printf "${darkred} Mainsail is already installed!${white}\n\n"
             			elif [ ! -d "$DIR3" ]; then
@@ -731,7 +731,7 @@ do
             			;;
             	    8)
                         DIR=/etc/boot-display
-                        URL="https://github.com/Guilouz/Creality-K1-and-K1-Max/raw/main/Scripts/files/boot-display/stock_boot_display.tar"
+                        URL="https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/Scripts/files/boot-display/stock_boot_display.tar"
             			if [ ! -d "$DIR" ]; then
             				printf "${darkred} Please use latest firmware to restore Stock Boot Display!${white}\n\n"
             			else


### PR DESCRIPTION
Apparently using raw url string "https://raw.githubusercontent.com/Guilouz/Creality-K1-and-K1-Max/main/.." instead of the base url resolves the issue. maybe consider updating the url in the wiki as well? 
 
However, the error still persists  for mainsail repo, didn't try fluidd installation tho..
Luckily, installing entware from the script, then using opkg to install wget-ssl resolves the issue for all urls.

---- Wiki proposed page ---

if you encounter the following error during the installation process:

"wget: TLS error from peer (alert code 80): 80
 wget: error getting response: Connection reset by peer
 Download failed. Exit code: 1"

Follow the steps to Install Entware first
> [wiki-url](https://github.com/Guilouz/Creality-K1-and-K1-Max/wiki/Install-Entware)

Log out and back in to your ssh session
> [wiki-url](https://github.com/Guilouz/Creality-K1-and-K1-Max/wiki/SSH-Connection)

 Install the following package <wget-ssl> using this command:
> opkg install wget-ssl

Run the installation script again and the issue should be resolved
> cd && sh ./installer.sh

 ---- End ---
 